### PR TITLE
SysCtrlToNavCPU Protobuf to ROS Message Translation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   sensor_msgs
   geometry_msgs
+  message_generation
 )
 
 ## System dependencies are found with CMake's conventions
@@ -49,11 +50,10 @@ find_package(catkin REQUIRED COMPONENTS
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
+add_message_files(
+   FILES
+   NavCommand.msg
+)
 
 ## Generate services in the 'srv' folder
 # add_service_files(
@@ -70,10 +70,11 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs
-# )
+generate_messages(
+   DEPENDENCIES
+   std_msgs
+   sensor_msgs
+)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
@@ -108,6 +109,7 @@ catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES monarc_uart_driver
 #  CATKIN_DEPENDS roscpp std_msgs
+   CATKIN_DEPENDS message_runtime
 #  DEPENDS system_lib
 )
 

--- a/msg/NavCommand.msg
+++ b/msg/NavCommand.msg
@@ -1,0 +1,2 @@
+int8 command_number
+sensor_msgs/NavSatFix command_location

--- a/package.xml
+++ b/package.xml
@@ -34,12 +34,14 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>serial</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/monarc_uart_driver_node.cpp
+++ b/src/monarc_uart_driver_node.cpp
@@ -5,6 +5,7 @@
 
 #include "ros/ros.h"
 #include "std_msgs/Int32.h"
+#include "sensor_msgs/Imu.h"
 #include "sensor_msgs/NavSatFix.h"
 #include "sensor_msgs/NavSatStatus.h"
 
@@ -17,7 +18,9 @@ void uart_reader(UartHandler* uart) {
   /*
    * Advertise on a group of topics.
    */
-  ros::Publisher atmospheric_pressure_pub = nh.advertise<std_msgs::Int32>("atmospheric_pressure", 1000);
+  ros::Publisher atmospheric_pressure_pub = nh.advertise<std_msgs::Int32>("atmospheric_pressure", 100);
+  ros::Publisher imu_pub = nh.advertise<sensor_msgs::Imu>("imu_data", 100);
+  ros::Publisher ultrasound_altitude_pub = nh.advertise<std_msgs::Int32>("ultrasound_altitude", 100);
 
   while (ros::ok()) {
     /*
@@ -47,6 +50,23 @@ void uart_reader(UartHandler* uart) {
       std_msgs::Int32 atmospheric_pressure;
       atmospheric_pressure.data = telemetry.atmospheric_pressure();
       atmospheric_pressure_pub.publish(atmospheric_pressure);
+
+      sensor_msgs::Imu imu_data;
+      imu_data.header.seq = 1;
+      imu_data.header.stamp.sec = 100;
+      imu_data.header.stamp.nsec = 100000;
+      imu_data.header.frame_id = "no frame";
+
+      imu_data.orientation.x = (double) telemetry.magnetometer().x();
+      imu_data.orientation.y = (double) telemetry.magnetometer().y();
+      imu_data.orientation.z = (double) telemetry.magnetometer().z();
+      imu_data.orientation.w = -1;
+      imu_data.orientation_covariance[0] = -1;
+
+      imu_data.angular_velocity.x = (double) telemetry.gyroscope().x();
+      imu_data.angular_velocity.y = (double) telemetry.gyroscope().y();
+      imu_data.angular_velocity.z = (double) telemetry.gyroscope().z();
+      imu_data.angular_velocity_covariance[0] = -1;
     }
   }
 }


### PR DESCRIPTION
This branch holds an initial implementation of the SysCtrlToNavCPU protobuf to ROS message translation. It translates all of the currently relevant fields in the aforementioned protobuf into ROS messages and publishes them to their related topics. 

In order to translate, it also declares a custom ROS message type called NavCommand. NavCommand currently consists of an int8 for the command number, and a NavSatFix ROS message. That was our originally agreed upon implementation, but since NavSatFix includes info like the GPS status which is not relevant here (this is a command to go to a location, not a GPS reading) I think it might be worth changing the NavCommand msg to the following:
```
Header header 
int8 command_number
float64 latitude
float64 longitude
floar64 altitude
```

But let me know what you think.